### PR TITLE
Fix workerCount property in spec argument

### DIFF
--- a/test/http-test.js
+++ b/test/http-test.js
@@ -14,7 +14,7 @@ test('communication with http server', function (assert) {
     var supervisor = new ClusterSupervisor({
         respawnWorkerCount: 0,
         exec: path.join(__dirname, 'hodor-http-server.js'),
-        numCPUs: numCPUs,
+        workerCount: numCPUs,
         createEnvironment: function () {
             return {
                 PROCESS_LOGICAL_ID: this.id

--- a/test/round-robin-test.js
+++ b/test/round-robin-test.js
@@ -17,7 +17,7 @@ test('communication with net server', function (assert) {
     var supervisor = new ClusterSupervisor({
         respawnWorkerCount: 0,
         exec: path.join(__dirname, 'hodor-net-server.js'),
-        numCPUs: numCPUs,
+        workerCount: numCPUs,
         createEnvironment: function () {
             return {
                 HODOR_NAME: this.id,


### PR DESCRIPTION
What:
Fixes the http-test.js and round-robin-tests.js tests

Why: 
The tests as they are right now are broken. I verified that the cluster-supervisor flow was working fine. The issue was the wrong naming of the workerCount property (named as numCPUs).