### PR TITLE
Improving README with minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Any attempt to listen for incomming connections with a `net`, `http`, or
 
 ```js
 // launcher.js
+var path = require('path');
 var ClusterSupervisor = require("nanny");
 var supervisor = new ClusterSupervisor({
     workerPath: path.join(__dirname, "server.js"),

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ By default, this is empty.
 The number of workers to maintain.
 Each worker will be assigned its 0-base index for its logical identifier.
 The default worker count is the number of logical CPU's on the host machine
-as reported by `process.cpus().length`.
+as reported by `os.cpus().length`.
 
 The worker count is **optional** but cannot be provided if you instead provide
 `logicalIds`.


### PR DESCRIPTION
What:
1. Adding path import to launcher class in README.
2. process.cpus().length --> os.cpus().lenght 

Why:
1. Examples in document should ideally work off the shelf. The current example launcher errors out as it is unable to load the path module.
2. cpus() is a function of the os object