### PR TITLE
Correctly naming the workerCount property

### DIFF
--- a/test/cluster-supervisor-custom-init-test.js
+++ b/test/cluster-supervisor-custom-init-test.js
@@ -11,7 +11,7 @@ test('extended init ClusterSupervisor', function (assert) {
         },
         exec: path.join(__dirname, 'mock-server.js'),
         respawnWorkerCount: 0,
-        numCPUs: 8
+        workerCount: 8
     });
 
     supervisor.start();

--- a/test/connection-forwarding-test.js
+++ b/test/connection-forwarding-test.js
@@ -11,7 +11,7 @@ test('connection forwarding', function (assert) {
     var supervisor = new ClusterSupervisor({
         respawnWorkerCount: 0,
         exec: path.join(__dirname, 'connection-forwarding-server.js'),
-        numCPUs: 4
+        workerCount: 4
     });
 
     supervisor.start();

--- a/test/hodor-net-client-cluster.js
+++ b/test/hodor-net-client-cluster.js
@@ -7,7 +7,7 @@ var path = require('path');
 var supervisor = new ClusterSupervisor({
     respawnWorkerCount: 0,
     exec: path.join(__dirname, 'hodor-net-client.js'),
-    numCPUs: 4,
+    workerCount: 4,
     pulse: 100,
     unhealthyTimeout: 5e3,
     createEnvironment: function (name) {

--- a/test/hodor-net-server-cluster.js
+++ b/test/hodor-net-server-cluster.js
@@ -7,7 +7,7 @@ var path = require('path');
 var supervisor = new ClusterSupervisor({
     respawnWorkerCount: 0,
     exec: path.join(__dirname, 'hodor-net-server.js'),
-    numCPUs: 4,
+    workerCount: 4,
     pulse: 100,
     unhealthyTimeout: 5e3,
     createEnvironment: function () {


### PR DESCRIPTION
What:
Fixes all tests which invoke the ClusterSupervisor constructor with numCPUs.

Why:
workerCount and not numCPUs is the right name for this property.
https://github.com/uber/nanny/blob/master/cluster-supervisor.js#L318.

The reason this might have gone unnoticed is because we default to os.cpus() : https://github.com/uber/nanny/blob/master/cluster-supervisor.js#L325-L329.
But when I spun up a cloud server with os.cpus().lenghth = 2 (as opposed to 8 on my mac book pro), I could uncover this issue.

