### PR TITLE
Event order + Fixes

### DIFF
--- a/cluster-supervisor.js
+++ b/cluster-supervisor.js
@@ -207,7 +207,9 @@ ClusterSupervisor.prototype._spawnWorker = function (logicalId) {
     worker.on('close', this.handleWorkerCloseRequest);
     worker.on('bounce', this.handleWorkerBounce);
     worker.on('standby', this.handleWorkerStandby);
-    worker.start();
+    process.nextTick(function startWorker() {
+        worker.start();
+    });
     this.workers.push(worker);
 };
 

--- a/test/connection-forwarding-test.js
+++ b/test/connection-forwarding-test.js
@@ -25,7 +25,7 @@ test('connection forwarding', function (assert) {
                 onlistening(port);
             }
         }
-        worker.process.on('message', onmessage);
+        worker.on('message', onmessage);
     });
 
 

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -31,7 +31,7 @@ test('communication with http server', function (assert) {
                 onlistening(port);
             }
         }
-        worker.process.on('message', onmessage);
+        worker.on('message', onmessage);
     });
 
     var listening = 0;

--- a/test/main-module-test.js
+++ b/test/main-module-test.js
@@ -13,7 +13,7 @@ tape('main module should be worker module', function (assert) {
     });
 
     supervisor.start();
-    supervisor.workers[0].process.on('message', function (message) {
+    supervisor.workers[0].on('message', function (message) {
         if (message.cmd === 'TEST_RESULT') {
             assert.ok(message.result, 'main module is the worker module');
             supervisor.stop(assert.end);

--- a/test/round-robin-test.js
+++ b/test/round-robin-test.js
@@ -35,7 +35,7 @@ test('communication with net server', function (assert) {
                 onlistening(port);
             }
         }
-        worker.process.on('message', onmessage);
+        worker.on('message', onmessage);
     });
 
     var listening = 0;

--- a/test/worker-argv-test.js
+++ b/test/worker-argv-test.js
@@ -16,7 +16,7 @@ tape('worker should receive same process.argv as non-worker', function (assert) 
     });
 
     supervisor.start();
-    supervisor.workers[0].process.on('message', function (message) {
+    supervisor.workers[0].on('message', function (message) {
         if (message.cmd === 'TEST_RESULT') {
             assert.strictEqual(message.result.length, 3);
             assert.strictEqual(message.result[1], workerPath);

--- a/worker-supervisor.js
+++ b/worker-supervisor.js
@@ -433,7 +433,10 @@ Standby.prototype.restart = function () {
         this.startDelayHandle = setTimeout(function () {
             worker.start();
         }, restartDelay);
+    } else {
+        worker.start();
     }
+
     return this;
 };
 

--- a/worker-supervisor.js
+++ b/worker-supervisor.js
@@ -339,6 +339,8 @@ WorkerSupervisor.prototype.handleMessage = function (message, handle) {
             message: message
         });
     }
+
+    this.emit('message', message, handle);
 };
 
 WorkerSupervisor.prototype.handleConnection = function (port, connection) {


### PR DESCRIPTION
Worker state change events need to be hooked up before the process is started. This is achieved by initializing the process on next tick.

However, this breaks the assumption that worker.process exists immediately after initialization. To work around this, we re-emit the process message on the worker and subscribe to `worker.on('message', ...)` instead.

Also fixes a minor edge case where workers do not restart if the restart delay is 0. 
